### PR TITLE
Add missing stateclass to inverter temperature entity

### DIFF
--- a/custom_components/sunstrong_pvs/sensor.py
+++ b/custom_components/sunstrong_pvs/sensor.py
@@ -143,6 +143,7 @@ INVERTER_SENSORS = (
         key="temperature",
         translation_key="temperature",
         native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
         device_class=SensorDeviceClass.TEMPERATURE,
         value_fn=attrgetter("last_report_temperature_c"),
     ),


### PR DESCRIPTION
Stateclass was inadvertently not defined for the temperature entity on the inverters.

Resolves https://github.com/SunStrong-Management/pvs-hass/issues/8