### PR TITLE
Update requirements for pypvs version to be >=0.2.8

### DIFF
--- a/custom_components/sunstrong_pvs/manifest.json
+++ b/custom_components/sunstrong_pvs/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/SunStrong-Management/pvs-hass",
   "iot_class": "local_polling",
   "loggers": ["pypvs"],
-  "requirements": ["bcrypt", "pypvs"],
+  "requirements": ["bcrypt", "pypvs>=0.2.8"],
   "zeroconf": [
     {
       "type": "_pvs6._tcp.local."


### PR DESCRIPTION
So apparently, if we don't specify a version for pypvs in the manifest HA won't update the package if it sees it already installed. Quick update to set this to >=0.2.8 (the minimum release for pvs_websocket module). This will ensure HA updates the package on startup.

I tested this by manually downgrading pypvs to 0.2.7 and restarting HA. I saw the same error about pvs_websocket not being found. Multiple restarts made no difference, HA sees pypvs installed and says "good enough". Adding >=0.2.8 then restarting HA made HA update it immediately and the integration started without an issue.

This will resolve https://github.com/SunStrong-Management/pvs-hass/issues/29

