### PR TITLE
Ensure websocket telemetry is enabled on websocket startup

### DIFF
--- a/custom_components/sunstrong_pvs/coordinator.py
+++ b/custom_components/sunstrong_pvs/coordinator.py
@@ -8,7 +8,7 @@ from datetime import timedelta
 from typing import Any
 
 from pypvs.pvs import PVS
-from pypvs.pvs_websocket import ConnectionState, PVSWebSocket
+from pypvs.pvs_websocket import ConnectionState
 from pypvs.exceptions import PVSError
 
 from homeassistant.config_entries import ConfigEntry
@@ -50,9 +50,10 @@ class PVSUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._setup_complete = False
         self.pvs_firmware = ""
 
-        # WebSocket for live data (managed by pypvs)
-        host = entry.data.get(CONF_HOST)
-        self._websocket = PVSWebSocket(host) if host else None
+        # WebSocket for live data — use pvs.get_websocket() so the
+        # enable_callback is wired up and telemetry is re-enabled on
+        # each connection attempt.
+        self._websocket = pvs.get_websocket() if entry.data.get(CONF_HOST) else None
         self._websocket_listener_remove: CALLBACK_TYPE | None = None
         self._websocket_state_listener_remove: CALLBACK_TYPE | None = None
         self._stop_listener: CALLBACK_TYPE | None = None


### PR DESCRIPTION
This is a result of the follow-on discussion from https://github.com/SunStrong-Management/pvs-hass/issues/29 where some individuals were noticing no live data being populated. I had a suspicion that these users had telemetry disabled and it wasn't being automatically enabled. To test I set `/sys/telemetryws/enable=0` on my PVS and restarted HA. After restart I too was not getting any live data reporting, confirming an issue with the integration. 

@bzyx you correctly asked me to add a callback to ensure the websocket telemetry is enabled when the websocket connection is established. This was done in the pypvs library, however I missed this in the coordinator configuration for the integration. Since it was constructing the websocket connection itself `PVSWebSocket(host)`, it was not triggering the enable_callback in `pvs.get_websocket()` to set `/sys/telemetryws/enable=1`. After this change, I restarted HA and confirmed telemetry on my system was automatically enabled as expected.