### PR TITLE
Add support for native HA integration diagnostics

### DIFF
--- a/custom_components/sunstrong_pvs/diagnostics.py
+++ b/custom_components/sunstrong_pvs/diagnostics.py
@@ -1,0 +1,86 @@
+"""Diagnostics support for PVS."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from .coordinator import PVSConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+# Config entry keys that contain sensitive data
+TO_REDACT_CONFIG = {"password"}
+
+# Data keys that could contain sensitive info
+TO_REDACT_DATA = {"mac"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: PVSConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    pvs_data = coordinator.pvs.data
+
+    diag: dict[str, Any] = {
+        "config_entry": async_redact_data(entry.as_dict(), TO_REDACT_CONFIG),
+        "pvs_serial": coordinator.pvs_serial_number,
+        "pvs_firmware": coordinator.pvs_firmware,
+        "websocket_connected": coordinator.websocket_connected,
+    }
+
+    if pvs_data is None:
+        diag["data"] = None
+        return diag
+
+    data: dict[str, Any] = {}
+
+    if pvs_data.gateway:
+        data["gateway"] = async_redact_data(
+            asdict(pvs_data.gateway), TO_REDACT_DATA
+        )
+
+    if pvs_data.inverters:
+        data["inverters"] = {
+            sn: asdict(inv) for sn, inv in pvs_data.inverters.items()
+        }
+
+    if pvs_data.meters:
+        data["meters"] = {
+            sn: asdict(meter) for sn, meter in pvs_data.meters.items()
+        }
+
+    if pvs_data.ess:
+        data["ess"] = {
+            sn: asdict(ess) for sn, ess in pvs_data.ess.items()
+        }
+
+    if pvs_data.transfer_switches:
+        data["transfer_switches"] = {
+            sn: asdict(ts) for sn, ts in pvs_data.transfer_switches.items()
+        }
+
+    data["raw"] = pvs_data.raw
+
+    # Include live data snapshot if websocket is active
+    live_data = coordinator.live_data
+    if live_data is not None:
+        data["live_data"] = asdict(live_data)
+
+    # Fetch telemetry websocket enable state directly from the PVS
+    try:
+        telemetry_enabled = await coordinator.pvs.getVarserverVar(
+            "/sys/telemetryws/enable"
+        )
+    except Exception:
+        _LOGGER.debug("Could not fetch telemetry websocket state", exc_info=True)
+        telemetry_enabled = "error"
+
+    diag["telemetry_websocket_enabled"] = telemetry_enabled
+    diag["data"] = data
+    return diag

--- a/custom_components/sunstrong_pvs/diagnostics.py
+++ b/custom_components/sunstrong_pvs/diagnostics.py
@@ -17,7 +17,7 @@ _LOGGER = logging.getLogger(__name__)
 TO_REDACT_CONFIG = {"password"}
 
 # Data keys that could contain sensitive info
-TO_REDACT_DATA = {"mac"}
+TO_REDACT_DATA = {"mac", "serial_number", "sn"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -41,9 +41,7 @@ async def async_get_config_entry_diagnostics(
     data: dict[str, Any] = {}
 
     if pvs_data.gateway:
-        data["gateway"] = async_redact_data(
-            asdict(pvs_data.gateway), TO_REDACT_DATA
-        )
+        data["gateway"] = asdict(pvs_data.gateway)
 
     if pvs_data.inverters:
         data["inverters"] = {
@@ -82,5 +80,5 @@ async def async_get_config_entry_diagnostics(
         telemetry_enabled = "error"
 
     diag["telemetry_websocket_enabled"] = telemetry_enabled
-    diag["data"] = data
+    diag["data"] = async_redact_data(data, TO_REDACT_DATA)
     return diag

--- a/custom_components/sunstrong_pvs/manifest.json
+++ b/custom_components/sunstrong_pvs/manifest.json
@@ -3,6 +3,7 @@
   "name": "PVS",
   "codeowners": ["@shondll"],
   "config_flow": true,
+  "dependencies": ["diagnostics"],
   "documentation": "https://github.com/SunStrong-Management/pvs-hass",
   "iot_class": "local_polling",
   "loggers": ["pypvs"],


### PR DESCRIPTION
Investigating the issues with live data reporting for some users made me realize it would be helpful to have the HA integration diagnostics implemented. Ref: https://developers.home-assistant.io/docs/core/integration/diagnostics/

Example diagnostics output from my system:
[config_entry-sunstrong_pvs-01KESZMK39V73AWMPWJ7MY69GP.json](https://github.com/user-attachments/files/26639007/config_entry-sunstrong_pvs-01KESZMK39V73AWMPWJ7MY69GP.json)
