### PR TITLE
Add flashwear as diagnostic sensor on the Gateway entity

### DIFF
--- a/custom_components/sunstrong_pvs/sensor.py
+++ b/custom_components/sunstrong_pvs/sensor.py
@@ -198,6 +198,14 @@ GATEWAY_SENSORS = (
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:information-outline",
     ),
+    PVSGatewaySensorEntityDescription(
+        key="flashwear_type_b",
+        translation_key="flashwear_type_b",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=attrgetter("flashwear_type_b_percent"),
+    ),
 )
 
 METER_SENSORS = (
@@ -669,6 +677,7 @@ async def async_setup_entry(
         entities.extend(
             PVSGatewayEntity(coordinator, description, pvs_data.gateway)
             for description in GATEWAY_SENSORS
+            if description.value_fn(pvs_data.gateway) is not None
         )
 
     if pvs_data.inverters:

--- a/custom_components/sunstrong_pvs/translations/en.json
+++ b/custom_components/sunstrong_pvs/translations/en.json
@@ -16,6 +16,9 @@
       "sw_version": {
         "name": "Firmware version"
       },
+      "flashwear_type_b": {
+        "name": "Flash wear (Type B)"
+      },
       "current_power_production": {
         "name": "Current Power Production"
       },


### PR DESCRIPTION
This adds support to the HA integration for showing the flashwear level. It has been added as a diagnostic sensor under the PVS Gateway entity. If the flashwear_type_b var doesn't exist (e.g. PVS5) the sensor will not get created.

This will fully resolve feature request https://github.com/SunStrong-Management/pvs-hass/issues/23

**NOTE** before publishing a release with this feature, the min pypvs version in the manifest will need to be updated to the next release version (presumably 0.3.0?) as it's required to support the new sensor.